### PR TITLE
Persistent menu & Nested Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ py36/
 /dist
 /example/**
 !/example/example.py
+!/example/persistent_menu_example.py

--- a/example/persistent_menu_example.py
+++ b/example/persistent_menu_example.py
@@ -1,0 +1,41 @@
+#-*- encoding:utf-8 -*-
+"""
+     In Persistent Menu,
+     Option Button is not allowed.
+     Sad..
+
+     How to register persistent menu:
+     python persistent_menu_example.py
+
+"""
+import os
+
+from nta import NaverTalkApi, Button
+
+NAVER_TALK_ACCESS_TOKEN = os.environ['naver_talk_access_token']
+ntalk = NaverTalkApi(NAVER_TALK_ACCESS_TOKEN)
+
+def my_callback(res, payload):
+    #callback function for showing result of send persistent menu payload
+    print(res)
+
+ntalk.persistent_menu(
+    menus=[
+        Button.ButtonText(
+            '고정 메뉴 테스트',
+            'PersistentMenu'
+        ),
+        Button.ButtonLink(
+            'Link to NTA',
+            'https://github.com/HwangWonYo/naver_talk_sdk'
+        ),
+        Button.ButtonNested(
+            title='버튼을 품은 버튼 이라는데?',
+            menus=[
+                Button.ButtonText('아무 의미 없는 버튼'),
+                Button.ButtonText('카드뷰 보기', 'CardView'),
+            ]
+        )
+    ],
+    callback=my_callback
+)

--- a/nta/api.py
+++ b/nta/api.py
@@ -267,7 +267,7 @@ class NaverTalkApi(object):
 
         self._send(payload, callback=callback)
 
-    def persistent_menu(self, menus, callback=None):
+    def persistent_menu(self, menus=None, callback=None):
         """
         enroll persistent menu.
 

--- a/nta/api.py
+++ b/nta/api.py
@@ -12,7 +12,10 @@ import json
 
 from .exceptions import NaverTalkApiError, NaverTalkApiConnectionError
 from .models.responses import NaverTalkResponse, NaverTalkImageResponse
-from .models.payload import ProfilePayload, GenericPayload, ImageUploadPayload, ThreadPayload, ActionPayload
+from .models.payload import (
+    ProfilePayload, GenericPayload, ImageUploadPayload, ThreadPayload, ActionPayload,
+    PersistentMenuPayload
+)
 from .models.events import *
 
 from .utils import LOGGER, PY3, _byteify
@@ -261,6 +264,17 @@ class NaverTalkApi(object):
             user=user_id,
             action="typingOff"
         )
+
+        self._send(payload, callback=callback)
+
+    def persistent_menu(self, menus, callback=None):
+        """
+        enroll persistent menu.
+
+        Args:
+            - menus: List of Buttons
+        """
+        payload = PersistentMenuPayload(menus)
 
         self._send(payload, callback=callback)
 

--- a/nta/models/__init__.py
+++ b/nta/models/__init__.py
@@ -11,13 +11,15 @@ from .payload import (
     GenericPayload,
     ThreadPayload,
     ActionPayload,
+    PersistentMenuPayload,
 )
 from .buttons import (
     ButtonLink,
     ButtonText,
     ButtonOption,
     Buttons,
-    ButtonPay
+    ButtonPay,
+    ButtonNested
 )
 from .template import (
     TextContent,

--- a/nta/models/base.py
+++ b/nta/models/base.py
@@ -42,8 +42,12 @@ class Base(object):
         """
         Return dictionary from this object.
         """
+        return self.convert_dict_to_camel_case(self.__dict__)
+
+    @classmethod
+    def convert_dict_to_camel_case(cls, d):
         data = {}
-        for key, sub_obj in self.__dict__.items():
+        for key, sub_obj in d.items():
             camel_key = utils.to_camel_case(key)
             if isinstance(sub_obj, (list, tuple, set)):
                 data[camel_key] = list()
@@ -51,12 +55,12 @@ class Base(object):
                     if hasattr(obj, 'as_json_dict'):
                         data[camel_key].append(obj.as_json_dict())
                     elif isinstance(obj, dict):
-                        data[camel_key].append(self.convert_dict_to_camel_case(obj))
+                        data[camel_key].append(cls.convert_dict_to_camel_case(obj))
                     else:
                         data[camel_key].append(obj)
 
             elif isinstance(sub_obj, dict):
-                data[camel_key] = self.convert_dict_to_camel_case(sub_obj)
+                data[camel_key] = cls.convert_dict_to_camel_case(sub_obj)
 
             elif hasattr(sub_obj, 'as_json_dict'):
                 data[camel_key] = sub_obj.as_json_dict()
@@ -65,19 +69,6 @@ class Base(object):
                 data[camel_key] = sub_obj
 
         return data
-
-    @classmethod
-    def convert_dict_to_camel_case(cls, d):
-        new_d = {}
-        for key, v in d.items():
-            camel_key = utils.to_camel_case(key)
-            if hasattr(v, 'as_json_dict'):
-                new_d[camel_key] = v.as_json_dict()
-            elif isinstance(v, dict):
-                new_d[camel_key] = cls.convert_dict_to_camel_case(v)
-            else:
-                new_d[camel_key] = v
-        return new_d
 
     @classmethod
     def new_from_json_dict(cls, data):

--- a/nta/models/buttons.py
+++ b/nta/models/buttons.py
@@ -130,3 +130,14 @@ class ButtonPay(Buttons):
         self.data = {
             'payment_info': payment_info
         }
+
+
+class ButtonNested(Buttons):
+    def __init__(self, title, menus, **kwargs):
+        super(ButtonNested, self).__init__(**kwargs)
+
+        self.type = 'NESTED'
+        self.data = {
+            'title': title,
+            'menus': menus
+        }

--- a/nta/models/events.py
+++ b/nta/models/events.py
@@ -1,5 +1,4 @@
 #-*- encoding:utf-8 -*-
-from .template import *
 from .base import Base
 
 class Event(Base):
@@ -24,6 +23,7 @@ class Event(Base):
     @property
     def mobile(self):
         return self.options.get('mobile')
+
 
 class OpenEvent(Event):
     """

--- a/nta/models/payload.py
+++ b/nta/models/payload.py
@@ -125,8 +125,10 @@ class ActionPayload(Payload):
 
 
 class PersistentMenuPayload(Base):
-    def __init__(self, menus, **kwargs):
+    def __init__(self, menus=None, **kwargs):
         super(PersistentMenuPayload, self).__init__(**kwargs)
 
         self.event = 'persistentMenu'
-        self.menu_content = [Menus(menus=menus)]
+        self.menu_content = []
+        if menus is not None:
+            self.menu_content = [Menus(menus=menus)]

--- a/nta/models/payload.py
+++ b/nta/models/payload.py
@@ -122,3 +122,11 @@ class ActionPayload(Payload):
         self.options = {
             "action": action
         }
+
+
+class PersistentMenuPayload(Base):
+    def __init__(self, menus, **kwargs):
+        super(PersistentMenuPayload, self).__init__(**kwargs)
+
+        self.event = 'persistentMenu'
+        self.menu_content = [Menus(menus=menus)]

--- a/nta/models/template.py
+++ b/nta/models/template.py
@@ -159,3 +159,10 @@ class ProductItem(Base):
         self.end_date = end_date
         self.seller_id = seller_id
         self.count = count
+
+
+class Menus(Base):
+    def __init__(self, menus, **kwargs):
+        super(Menus, self).__init__(**kwargs)
+
+        self.menus = menus

--- a/tests/api/test_persistent_menu.py
+++ b/tests/api/test_persistent_menu.py
@@ -106,3 +106,29 @@ class TestNaverTalkAPI(unittest.TestCase):
             callback=test_callback
         )
         self.assertEqual(counter.call_count, 1)
+
+    @responses.activate
+    def test_persistent_menu_with_None(self):
+        responses.add(
+            responses.POST,
+            NaverTalkApi.DEFAULT_API_ENDPOINT,
+            json={
+                "success": True,
+                "resultCode": "00"
+            },
+            status=200
+        )
+
+        counter = mock.MagicMock()
+        def test_callback(res, payload):
+            self.assertEqual(
+                payload,
+                {
+                    "event": "persistentMenu",
+                    "menuContent": []
+                }
+            )
+            counter()
+
+        self.tested.persistent_menu(callback=test_callback)
+        self.assertEqual(counter.call_count, 1)

--- a/tests/api/test_persistent_menu.py
+++ b/tests/api/test_persistent_menu.py
@@ -1,0 +1,108 @@
+#-*- encoding:utf-8 -*-
+import json
+import unittest
+import responses
+try:
+    from unittest import mock
+except:
+    import mock
+
+
+from nta import (
+    NaverTalkApi, Button
+)
+from nta.models import(
+    TextContent, QuickReply, ButtonText, ButtonLink
+)
+
+
+class TestNaverTalkAPI(unittest.TestCase):
+    def setUp(self):
+        self.tested = NaverTalkApi('test_naver_talk_access_token')
+
+    @responses.activate
+    def test_persistent_menu(self):
+        responses.add(
+            responses.POST,
+            NaverTalkApi.DEFAULT_API_ENDPOINT,
+            json={
+                "success": True,
+                "resultCode": "00"
+            },
+            status=200
+        )
+
+        counter = mock.MagicMock()
+        def test_callback(res, payload):
+            self.assertEqual(
+                payload,
+                {
+                    "event": "persistentMenu",
+                    "menuContent": [{
+                        "menus":
+                            [{
+                                "type": "TEXT",
+                                "data": {
+                                    "title": "챗봇 안내",
+                                    "code": "CHATBOT_GUIDE"
+                                }
+                            }, {
+                                "type": "LINK",
+                                "data": {
+                                    "title": "이벤트 페이지",
+                                    "url": "http://your-pc-url.com/event",
+                                    "mobileUrl": "http://your-mobile-url.com/event"
+                                }
+                            }, {
+                                "type": "LINK",
+                                "data": {
+                                    "title": "전화하기",
+                                    "url": "tel:021234567",
+                                    "mobileUrl": None
+                                }
+                            }, {
+                                "type": "NESTED",
+                                "data": {
+                                    "title": "공지사항",
+                                    "menus":
+                                        [{
+                                            "type": "LINK",
+                                            "data": {
+                                                "title": "교환/환불 안내",
+                                                "url": "http://your-pc-url.com/guide",
+                                                "mobileUrl": "http://your-mobile-url.com/guide"
+                                            }
+                                        }]
+                                }
+                            }]
+                    }]
+                }
+            )
+            counter()
+
+        self.tested.persistent_menu(
+            menus=[
+                Button.ButtonText(title='챗봇 안내', code='CHATBOT_GUIDE'),
+                Button.ButtonLink(
+                    title='이벤트 페이지',
+                    url='http://your-pc-url.com/event',
+                    mobile_url='http://your-mobile-url.com/event'
+                ),
+                Button.ButtonLink(
+                    title='전화하기',
+                    url='tel:021234567'
+                ),
+                Button.ButtonNested(
+                    title='공지사항',
+                    menus=[
+                        Button.ButtonLink(
+                            title="교환/환불 안내",
+                            url="http://your-pc-url.com/guide",
+                            mobile_url="http://your-mobile-url.com/guide"
+                        )
+                    ]
+                )
+            ],
+            callback=test_callback
+        )
+        self.assertEqual(counter.call_count, 1)

--- a/tests/models/test_buttons.py
+++ b/tests/models/test_buttons.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, absolute_import
 import unittest
 
 from nta.models import (
-    Buttons, ButtonText, ButtonPay, ButtonLink, ButtonOption,
+    Buttons, ButtonText, ButtonPay, ButtonLink, ButtonOption, ButtonNested,
     PaymentInfo, ProductItem
 )
 
@@ -138,6 +138,36 @@ class TestNaverTalkApi(unittest.TestCase):
                 }
             }
         )
+
+    def test_button_nested(self):
+        target = {
+			"type":"NESTED",
+			"data":{
+				"title":"공지사항",
+				"menus":
+				[{
+					"type":"LINK",
+					"data":{
+						"title":"교환/환불 안내",
+						"url":"http://your-pc-url.com/guide",
+						"mobileUrl":"http://your-mobile-url.com/guide"
+					}
+				}]
+			}
+        }
+        btn = ButtonNested(
+            title='공지사항',
+            menus=[
+                ButtonLink(
+                    title='교환/환불 안내',
+                    url='http://your-pc-url.com/guide',
+                    mobile_url='http://your-mobile-url.com/guide'
+                )
+            ]
+        )
+
+        self.assertEqual(btn, target)
+
 
 
 if __name__ == '__main__':

--- a/tests/models/test_events.py
+++ b/tests/models/test_events.py
@@ -8,18 +8,5 @@ from nta.models import (
 )
 
 class TestNaverTalkEvent(unittest.TestCase):
-    def test_echo_event(self):
-        event = {
-            "standby": True,
-            "event": "send",
-            "user": "al-2eGuGr5WQOnco1_V-FQ",
-            "partner": "wc8b1i",
-            "textContent": {
-                "text": "헬로",
-                "inputType": "typing"
-            },
-            "options": {
-                "mobile": False
-             }
-        }
-
+    def test_peresistent_menu_event(self):
+        pass

--- a/tests/models/test_payload.py
+++ b/tests/models/test_payload.py
@@ -76,3 +76,13 @@ class TestNaverTalkPayload(unittest.TestCase):
             ]
         )
         self.assertEqual(target, payload)
+
+    def test_persistent_menu_with_None(self):
+        payload = PersistentMenuPayload()
+        self.assertEqual(
+            payload,
+            {
+                "event":"persistentMenu",
+                "menuContent" : []
+            }
+        )

--- a/tests/models/test_payload.py
+++ b/tests/models/test_payload.py
@@ -1,0 +1,78 @@
+#-*- encoding:utf8 -*-
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+from nta.models.payload import (
+    PersistentMenuPayload
+)
+from nta import Button
+
+class TestNaverTalkPayload(unittest.TestCase):
+    def test_persistent_menu(self):
+        target = {
+            "event":"persistentMenu",
+            "menuContent" : [{
+                "menus":
+                [{
+                    "type":"TEXT",
+                    "data":{
+                        "title":"챗봇 안내",
+                        "code":"CHATBOT_GUIDE"
+                    }
+                },{
+                    "type":"LINK",
+                    "data":{
+                        "title":"이벤트 페이지",
+                        "url":"http://your-pc-url.com/event",
+                        "mobileUrl":"http://your-mobile-url.com/event"
+                    }
+                },{
+                    "type":"LINK",
+                    "data":{
+                        "title":"전화하기",
+                        "url":"tel:021234567",
+                        "mobileUrl": None
+                    }
+                },{
+                    "type":"NESTED",
+                    "data":{
+                        "title":"공지사항",
+                        "menus":
+                        [{
+                            "type":"LINK",
+                            "data":{
+                                "title":"교환/환불 안내",
+                                "url":"http://your-pc-url.com/guide",
+                                "mobileUrl":"http://your-mobile-url.com/guide"
+                            }
+                        }]
+                    }
+                }]
+            }]
+        }
+        payload = PersistentMenuPayload(
+            menus=[
+                Button.ButtonText(title='챗봇 안내', code='CHATBOT_GUIDE'),
+                Button.ButtonLink(
+                    title='이벤트 페이지',
+                    url='http://your-pc-url.com/event',
+                    mobile_url='http://your-mobile-url.com/event'
+                ),
+                Button.ButtonLink(
+                    title='전화하기',
+                    url='tel:021234567'
+                ),
+                Button.ButtonNested(
+                    title='공지사항',
+                    menus=[
+                        Button.ButtonLink(
+                            title="교환/환불 안내",
+                            url="http://your-pc-url.com/guide",
+                            mobile_url="http://your-mobile-url.com/guide"
+                        )
+                    ]
+                )
+            ]
+        )
+        self.assertEqual(target, payload)


### PR DESCRIPTION
# Description
Persistent Menu is type of payload.
Nested Button is type of button template.

- Add Persistent Menu Payload in payload.py
- Add method to send persistent menu payload in api.py
- Add Button Nested in button.py
- Cover test for persistent menu and nested button

See Issue #23 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
